### PR TITLE
PistonWindow uses gfx::Canvas (WIP)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,10 @@ use graphics::Context;
 pub struct PistonWindow<W: window::Window, T = ()> {
     /// The window.
     pub window: Rc<RefCell<W>>,
-    /// The gfx data.
-    pub gfx: Rc<RefCell<Gfx>>,
+    /// The gfx Canvas
+    pub canvas: Rc<RefCell<gfx::Canvas<gfx_device_gl::Output, gfx_device_gl::Device, gfx_device_gl::Factory>>>,
+    /// Gfx2d
+    pub g2d: Rc<RefCell<Gfx2d<gfx_device_gl::Resources>>>,
     /// The event loop.
     pub events: Rc<RefCell<event::events::Events<W, event::Event<W::Event>>>>,
     /// The event.
@@ -37,20 +39,13 @@ impl<W, T> Clone for PistonWindow<W, T>
     fn clone(&self) -> Self {
         PistonWindow {
             window: self.window.clone(),
-            gfx: self.gfx.clone(),
+            canvas: self.canvas.clone(),
+            g2d: self.g2d.clone(),
             events: self.events.clone(),
             event: self.event.clone(),
             app: self.app.clone(),
         }
     }
-}
-
-/// Contains Gfx data.
-pub struct Gfx {
-    /// Canvas
-    pub canvas: gfx::Canvas<gfx_device_gl::Output, gfx_device_gl::Device, gfx_device_gl::Factory>,
-    /// Gfx2d.
-    pub g2d: Gfx2d<gfx_device_gl::Resources>,
 }
 
 impl<W, T> PistonWindow<W, T>
@@ -74,10 +69,8 @@ impl<W, T> PistonWindow<W, T>
 
         PistonWindow {
             window: window.clone(),
-            gfx: Rc::new(RefCell::new(Gfx {
-                canvas: canvas,
-                g2d: g2d,
-            })),
+            canvas: Rc::new(RefCell::new(canvas)),
+            g2d: Rc::new(RefCell::new(g2d)),
             events: Rc::new(RefCell::new(window.events())),
             event: None,
             app: app,
@@ -88,7 +81,8 @@ impl<W, T> PistonWindow<W, T>
     pub fn app<U>(self, app: Rc<RefCell<U>>) -> PistonWindow<W, U> {
         PistonWindow {
             window: self.window,
-            gfx: self.gfx,
+            canvas: self.canvas,
+            g2d: self.g2d,
             events: self.events,
             event: self.event,
             app: app,
@@ -106,20 +100,14 @@ impl<W, T> PistonWindow<W, T>
         if let Some(ref e) = self.event {
             if let Some(args) = e.render_args() {
 
-                let &mut Gfx {
-                    ref mut canvas,
-                    ref mut g2d,
-                    ..
-                } = &mut *self.gfx.borrow_mut();
-
                 let &mut gfx::Canvas {
                     ref mut device,
                     ref mut renderer,
                     ref mut output,
                     ..
-                } = canvas;
+                } = &mut *self.canvas.borrow_mut();
 
-                g2d.draw(renderer, output, args.viewport(), f);
+                self.g2d.borrow_mut().draw(renderer, output, args.viewport(), f);
                 device.submit(renderer.as_buffer());
                 renderer.reset();
             }
@@ -128,13 +116,13 @@ impl<W, T> PistonWindow<W, T>
 
     /// Renders 3D graphics.
     pub fn draw_3d<F>(&self, mut f: F)
-        where F: FnMut(&mut Gfx)
+        where F: FnMut(&mut gfx::Canvas<gfx_device_gl::Output, gfx_device_gl::Device, gfx_device_gl::Factory>)
     {
         use piston::event::RenderEvent;
 
         if let Some(ref e) = self.event {
             if let Some(_) = e.render_args() {
-                f(&mut *self.gfx.borrow_mut())
+                f(&mut *self.canvas.borrow_mut())
             }
         }
     }
@@ -151,31 +139,33 @@ impl<W, T> Iterator for PistonWindow<W, T>
         if let Some(e) = self.events.borrow_mut().next() {
             if let Some(_) = e.after_render_args() {
                 // After swapping buffers.
-                let &mut Gfx {
-                    ref mut canvas,
+
+                let &mut gfx::Canvas {
+                    ref mut device,
+                    ref mut factory,
                     ..
-                } = &mut *self.gfx.borrow_mut();
-                canvas.device.after_frame();
-                canvas.factory.cleanup();
+                } = &mut *self.canvas.borrow_mut();
+
+                device.after_frame();
+                factory.cleanup();
+
             }
 
             if let Some(size) = e.resize_args() {
-                let &mut Gfx {
-                    ref mut canvas,
-                    ..
-                } = &mut *self.gfx.borrow_mut();
 
                 let &mut gfx::Canvas {
                     ref mut output,
+                    ref mut factory,
                     ..
-                } = canvas;
+                } = &mut *self.canvas.borrow_mut();
 
-                *output = canvas.factory.make_fake_output(size[0] as u16, size[1] as u16);
+                *output = factory.make_fake_output(size[0] as u16, size[1] as u16);
             }
 
             Some(PistonWindow {
                 window: self.window.clone(),
-                gfx: self.gfx.clone(),
+                canvas: self.canvas.clone(),
+                g2d: self.g2d.clone(),
                 events: self.events.clone(),
                 event: Some(e),
                 app: self.app.clone(),
@@ -206,7 +196,8 @@ impl<W, T> event::GenericEvent for PistonWindow<W, T>
                 Some(e) => {
                     Some(PistonWindow {
                         window: old_event.window.clone(),
-                        gfx: old_event.gfx.clone(),
+                        canvas: old_event.canvas.clone(),
+                        g2d: old_event.g2d.clone(),
                         events: old_event.events.clone(),
                         event: Some(e),
                         app: old_event.app.clone(),


### PR DESCRIPTION
Haven't tested with anything yet. Probably breaks examples.
- [ ] Fix examples in piston_examples