### PR TITLE
Reexport everything you need

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ git = "https://github.com/pistondevelopers/gfx_graphics"
 [dependencies.piston2d-graphics]
 git = "https://github.com/pistondevelopers/graphics"
 
-[dev-dependencies.pistoncore-glutin_window]
+[dependencies.pistoncore-glutin_window]
 #git = "https://github.com/pistondevelopers/glutin_window"
 version = "0.0.8"
+
+[dependencies.shader_version]
+#git = "https://github.com/PistonDevelopers/shader_version"
+version = "0.0.6"

--- a/examples/hello_piston.rs
+++ b/examples/hello_piston.rs
@@ -1,24 +1,13 @@
 extern crate piston_window;
-extern crate glutin_window;
-extern crate piston;
-extern crate graphics;
 
-use std::cell::RefCell;
-use std::rc::Rc;
-use glutin_window::{ OpenGL, GlutinWindow };
 use piston_window::*;
-use piston::window::WindowSettings;
-
-use piston::event::*;
-use graphics::*;
-use piston::input::*;
 
 fn main() {
-    let window = Rc::new(RefCell::new(GlutinWindow::new(
-        OpenGL::_3_2,
-        WindowSettings::new("Hello Piston!", [640, 480])
+    let window = window(
+            OpenGL::_3_2,
+            WindowSettings::new("Hello Piston!", [640, 480])
             .exit_on_esc(true)
-    )));
+        );
     println!("Press any button to enter inner loop");
     for e in PistonWindow::new(window, empty_app()) {
         e.draw_2d(|_c, g| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,15 @@ extern crate gfx;
 extern crate gfx_device_gl;
 extern crate gfx_graphics;
 extern crate graphics;
+extern crate shader_version;
+extern crate glutin_window;
+
+use glutin_window::GlutinWindow;
+pub use shader_version::OpenGL;
+pub use graphics::*;
+pub use piston::window::*;
+pub use piston::event::*;
+pub use piston::input::*;
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -15,10 +24,18 @@ use std::any::Any;
 use piston::{ event, window };
 use gfx::traits::*;
 use gfx_graphics::{ Gfx2d, GfxGraphics };
-use graphics::Context;
 
 /// Actual gfx::Stream implementation carried by the window.
 pub type GfxStream = gfx::OwnedStream<gfx_device_gl::Device, gfx_device_gl::Output>;
+/// Glyph cache.
+type PistonGlyphCache = gfx_graphics::GlyphCache<gfx_device_gl::Resources, gfx_device_gl::Factory>;
+/// 2D graphics.
+type PistonGraphics<'a> = GfxGraphics<'a, gfx_device_gl::Resources, gfx_device_gl::CommandBuffer, gfx_device_gl::Output>;
+
+/// Creates a window using default window back-end.
+pub fn window(opengl: OpenGL, settings: WindowSettings) -> Rc<RefCell<GlutinWindow>> {
+    Rc::new(RefCell::new(GlutinWindow::new(opengl, settings)))
+}
 
 /// Contains everything required for controlling window, graphics, event loop.
 pub struct PistonWindow<W: window::Window, T = ()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub fn window(opengl: OpenGL, settings: WindowSettings) -> Rc<RefCell<GlutinWind
 }
 
 /// Contains everything required for controlling window, graphics, event loop.
-pub struct PistonWindow<W: window::Window, T = ()> {
+pub struct PistonWindow<W: window::Window = GlutinWindow, T = ()> {
     /// The window.
     pub window: Rc<RefCell<W>>,
     /// GFX stream.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@ use gfx_graphics::{ Gfx2d, GfxGraphics };
 /// Actual gfx::Stream implementation carried by the window.
 pub type GfxStream = gfx::OwnedStream<gfx_device_gl::Device, gfx_device_gl::Output>;
 /// Glyph cache.
-type PistonGlyphCache = gfx_graphics::GlyphCache<gfx_device_gl::Resources, gfx_device_gl::Factory>;
+type Glyphs = gfx_graphics::GlyphCache<gfx_device_gl::Resources, gfx_device_gl::Factory>;
 /// 2D graphics.
-type PistonGraphics<'a> = GfxGraphics<'a, gfx_device_gl::Resources, gfx_device_gl::CommandBuffer, gfx_device_gl::Output>;
+type G2d<'a> = GfxGraphics<'a, gfx_device_gl::Resources, gfx_device_gl::CommandBuffer, gfx_device_gl::Output>;
 
 /// Creates a window using default window back-end.
 pub fn window(opengl: OpenGL, settings: WindowSettings) -> Rc<RefCell<GlutinWindow>> {


### PR DESCRIPTION
DO NOT MERGE YET!

Closes https://github.com/PistonDevelopers/piston_window/issues/32

* Reexports `shader_version::OpenGL`
* Reexports `graphics::*`
* Reexports `piston::window::*`
* Reexports `piston::event::*`
* Reexports `piston::input::*`
* Adds `Glyphs` type alias to `GfxGlyphCache`
* Adds `G2d` type alias to `GfxGraphics`
* Adds `window` for creating a window
* Uses `GlutinWindow` by default (so you can pass `PistonWindow`)