### PR TITLE
Updated to latest gfx and use crates.io dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_window"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["window", "piston"]
 description = "The official Piston window back-end for the Piston game engine"
@@ -15,22 +15,14 @@ homepage = "https://github.com/pistondevelopers/piston_window"
 path = "src/lib.rs"
 name = "piston_window"
 
-[dependencies.piston]
-#git = "https://github.com/pistondevelopers/piston"
-version = "0.1.3"
 
-[dependencies.gfx]
-git = "https://github.com/gfx-rs/gfx-rs"
+[dependencies]
+gfx = "0.6.0"
+gfx_device_gl = "0.4.0"
+piston = "0.1.3"
+piston2d-gfx_graphics = "0.1.20"
+piston2d-graphics = "0.0.48"
 
-[dependencies.gfx_device_gl]
-git = "https://github.com/gfx-rs/gfx_device_gl"
+[dev-dependencies]
+pistoncore-glutin_window = "0.0.8"
 
-[dependencies.piston2d-gfx_graphics]
-git = "https://github.com/pistondevelopers/gfx_graphics"
-
-[dependencies.piston2d-graphics]
-git = "https://github.com/pistondevelopers/graphics"
-
-[dev-dependencies.pistoncore-glutin_window]
-#git = "https://github.com/pistondevelopers/glutin_window"
-version = "0.0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ name = "piston_window"
 
 
 [dependencies]
-gfx = "0.6.0"
-gfx_device_gl = "0.4.0"
+gfx = "0.6.*"
+gfx_device_gl = "0.4.*"
 piston = "0.1.3"
 piston2d-gfx_graphics = "0.1.20"
 piston2d-graphics = "0.0.48"


### PR DESCRIPTION
This needs to be published before I can [add the examples back](https://github.com/PistonDevelopers/gfx_graphics/pull/245) into the gfx_graphics crate (I don't have publish auth).

Ping @bvssvni :smile_cat: 