### PR TITLE
Reexport `Flip`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_window"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["window", "piston"]
 description = "The official Piston window back-end for the Piston game engine"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use graphics::*;
 pub use piston::window::*;
 pub use piston::event::*;
 pub use piston::input::*;
-pub use gfx_graphics::{ Texture, TextureSettings };
+pub use gfx_graphics::{ Texture, TextureSettings, Flip };
 
 use std::cell::RefCell;
 use std::rc::Rc;


### PR DESCRIPTION
Makes it possible to use `Texture::from_path` with adding a dependency
on gfx_graphics to Cargo.toml.