### PR TITLE
Updated dependencies, reexported `GlyphError`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_window"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["window", "piston"]
 description = "The official Piston window back-end for the Piston game engine"
@@ -19,8 +19,8 @@ name = "piston_window"
 [dependencies]
 gfx = "0.8.1"
 gfx_device_gl = "0.7.0"
-piston = "0.15.1"
-piston2d-gfx_graphics = "0.14.0"
+piston = "0.16.0"
+piston2d-gfx_graphics = "0.15.0"
 piston2d-graphics = "0.11.0"
 shader_version = "0.2.0"
-pistoncore-glutin_window = "0.17.0"
+pistoncore-glutin_window = "0.18.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use graphics::*;
 pub use piston::window::*;
 pub use piston::input::*;
 pub use piston::event_loop::*;
-pub use gfx_graphics::{ Texture, TextureSettings, Flip };
+pub use gfx_graphics::{ GlyphError, Texture, TextureSettings, Flip };
 
 use std::cell::RefCell;
 use std::rc::Rc;


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/piston_window/issues/103

- Bumped to 0.30.0