### PR TITLE
Updated to new Gfx design

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 
 name = "piston_window"
-version = "0.34.0"
+version = "0.35.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["window", "piston"]
-description = "The official Piston window back-end for the Piston game engine"
+description = "The official Piston window wrapper for the Piston game engine"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/pistondevelopers/piston_window.git"
@@ -17,10 +17,10 @@ name = "piston_window"
 
 
 [dependencies]
-gfx = "0.8.1"
-gfx_device_gl = "0.7.0"
+gfx = "0.9.0"
+gfx_device_gl = "0.8.0"
 piston = "0.17.0"
-piston2d-gfx_graphics = "0.18.0"
-piston2d-graphics = "0.13.0"
+piston2d-gfx_graphics = "0.19.0"
+piston2d-graphics = "0.14.0"
 shader_version = "0.2.0"
 pistoncore-glutin_window = "0.20.0"


### PR DESCRIPTION
- Bumped to 0.35.0
- Changed “back-end” to “wrapper” in project description
- Updated dependencies
- Renamed “GfxStream” to “GfxEncoder”
- Added `PistonWindow::output_color`
- Added `PistonWindow::output_stencil`
- Pass OpenGL version and samples to `PistonWindow::new`
- Recreate main targets if window changes size