### PR TITLE
Updated dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_window"
-version = "0.35.0"
+version = "0.36.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["window", "piston"]
 description = "The official Piston window wrapper for the Piston game engine"
@@ -19,8 +19,8 @@ name = "piston_window"
 [dependencies]
 gfx = "0.9.0"
 gfx_device_gl = "0.8.0"
-piston = "0.17.0"
-piston2d-gfx_graphics = "0.19.0"
+piston = "0.18.0"
+piston2d-gfx_graphics = "0.20.0"
 piston2d-graphics = "0.14.0"
 shader_version = "0.2.0"
-pistoncore-glutin_window = "0.20.0"
+pistoncore-glutin_window = "0.21.0"


### PR DESCRIPTION
- Bumped to 0.36.0
- Use `Srgb8` instead of `Rgba8`
- Turn on sRGB (required by gfx_graphics)
- Improved docs