### PR TITLE
Expose a G2dTexture type (open to a better name) that is compatible with the exposed G2d type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_window"
-version = "0.36.1"
+version = "0.36.2"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["window", "piston"]
 description = "The official Piston window wrapper for the Piston game engine"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,8 @@ pub type Glyphs = gfx_graphics::GlyphCache<gfx_device_gl::Resources,
 pub type G2d<'a> = GfxGraphics<'a,
     gfx_device_gl::Resources,
     gfx_device_gl::command::CommandBuffer>;
+/// Texture type compatible with `G2d`.
+pub type G2dTexture<'a> = Texture<gfx_device_gl::Resources>;
 
 /// Contains everything required for controlling window, graphics, event loop.
 pub struct PistonWindow<T = (), W: Window = GlutinWindow> {


### PR DESCRIPTION
Should close #111 

cc @bvssvni 

Edit: Oh yeah, I just realised that type-wise, this is pretty easily accessible via the `G2d` associated type, i.e. `G2d::Texture`. Also, all of `GfxTexture`'s constructors take a `Factory` argument anyway, so its Factory type parameter may always be inferred via its use-case. Feel free to close this, however it might still be useful to avoid users running into issues like #111 anyway.

Edit2: Actually, it's not so easy to access it via the associated type, as it requires casting to the `Graphics` trait, i.e. `<G2d<'static> as Graphics>::Texture`. On the other hand, `G2dTexture` is probably quite a bit nicer.