### PR TITLE
Redesign (remove `PistonWindow::app`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_window"
-version = "0.43.0"
+version = "0.44.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["window", "piston"]
 description = "The official Piston window wrapper for the Piston game engine"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Piston-Window is designed for only one purpose: Convenience.
 * Reexports everything you need to write 2D interactive applications
 * `.draw_2d` for drawing 2D, and `.draw_3d` for drawing 3D
 * Uses Gfx to work with 3D libraries in the Piston ecosystem
-* A smart design to pass around the window and application state
 
 ```Rust
 extern crate piston_window;
@@ -26,36 +25,24 @@ fn main() {
 }
 ```
 
-If you want another convenience method, create a trait for it,
-and then implement it for `PistonWindow`.
-
 `PistonWindow` uses Glutin as window back-end by default,
 but you can change to another back-end, for example SDL2 or GLFW by changing the type parameter:
 
 ```Rust
-let mut window: PistonWindow<(), Sdl2Window> = WindowSettings::new("Hello Piston!", [640, 480])
+let mut window: PistonWindow<Sdl2Window> = WindowSettings::new("Hello Piston!", [640, 480])
     .exit_on_esc(true).build().unwrap();
 ```
 
-Games often follow a finite state machine logic.
-A common way to solve this is using an `enum` and a loop for the different states.
-This can be quite buggy, since you need to resolve the state for each event.
-
-Instead, you could pass around one `PistonWindow` to different functions that represents the states.
-This way you do not have to resolve the state, because it is part of the context.
-
 `PistonWindow` implements `AdvancedWindow`, `Window` and `EventLoop`.
-You can swap the application state with `.app` method.
 Nested game loops are supported, so you can have one inside another.
 
 ```Rust
 while let Some(e) = window.next() {
     if let Some(button) = e.press_args() {
-        let intro = e.app(start_intro());
-        while let Some(e) = intro.next() {
+        // Intro.
+        while let Some(e) = window.next() {
             ...
         }
-        window = into.app(());
     }
 }
 ```

--- a/examples/hello_piston.rs
+++ b/examples/hello_piston.rs
@@ -8,6 +8,7 @@ fn main() {
         .exit_on_esc(true)
         .build()
         .unwrap_or_else(|e| { panic!("Failed to build PistonWindow: {}", e) });
+        
     while let Some(e) = window.next() {
         window.draw_2d(&e, |c, g| {
             clear([0.5, 1.0, 0.5, 1.0], g);
@@ -15,10 +16,10 @@ fn main() {
         });
 
         if e.press_args().is_some() {
-            window = inner_event_loop(window.app(InnerApp {
+            InnerApp {
                 title: "Inner loop (press X to exit inner loop)",
                 exit_button: Button::Keyboard(Key::X),
-            }));
+            }.run(&mut window);
             window.set_title(title.into());
         }
     }
@@ -30,20 +31,19 @@ pub struct InnerApp {
     pub exit_button: Button,
 }
 
-fn inner_event_loop(mut window: PistonWindow<InnerApp>) -> PistonWindow {
-    window.set_title(window.app.title.into());
-    while let Some(e) = window.next() {
-        window.draw_2d(&e, |c, g| {
-            clear([0.5, 0.5, 1.0, 1.0], g);
-            ellipse([1.0, 0.0, 0.0, 1.0], [50.0, 50.0, 100.0, 100.0], c.transform, g);
-        });
-        if let Some(button) = e.press_args() {
-            if button == window.app.exit_button {
-                break;
+impl InnerApp {
+    pub fn run(&mut self, window: &mut PistonWindow) {
+        window.set_title(self.title.into());
+        while let Some(e) = window.next() {
+            window.draw_2d(&e, |c, g| {
+                clear([0.5, 0.5, 1.0, 1.0], g);
+                ellipse([1.0, 0.0, 0.0, 1.0], [50.0, 50.0, 100.0, 100.0], c.transform, g);
+            });
+            if let Some(button) = e.press_args() {
+                if button == self.exit_button {
+                    break;
+                }
             }
         }
     }
-
-    // Go back to default app state.
-    window.app(())
 }


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/piston_window/issues/136

- Bumped to 0.44.0
- Removed `PistonWindow::app` to allow using application state inside
`draw_2d`
- Pass `PistonWindow` to `draw_3d` to use other fields
- Updated docs
- Updated README