### PR TITLE
Call `self.window.make_current` in `draw_3d`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_window"
-version = "0.47.1"
+version = "0.47.2"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["window", "piston"]
 description = "The official Piston window wrapper for the Piston game engine"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,11 +226,13 @@ impl<W> PistonWindow<W>
 
     /// Renders 3D graphics.
     pub fn draw_3d<E, F, U>(&mut self, e: &E, f: F) -> Option<U> where
+        W: OpenGLWindow,
         E: GenericEvent,
         F: FnOnce(&mut Self) -> U
     {
         use piston::input::RenderEvent;
 
+        self.window.make_current();
         if let Some(_) = e.render_args() {
             let res = f(self);
             self.encoder.flush(&mut self.device);


### PR DESCRIPTION
This makes it possible to render 3D to multiple windows.

- Bumped to 0.47.2