### PR TITLE
Removed lifetime on `G2dTexture` alias

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_window"
-version = "0.58.0"
+version = "0.59.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["window", "piston"]
 description = "The official Piston window wrapper for the Piston game engine"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub type G2d<'a> = GfxGraphics<'a,
     gfx_device_gl::Resources,
     gfx_device_gl::CommandBuffer>;
 /// Texture type compatible with `G2d`.
-pub type G2dTexture<'a> = Texture<gfx_device_gl::Resources>;
+pub type G2dTexture = Texture<gfx_device_gl::Resources>;
 
 /// Contains everything required for controlling window, graphics, event loop.
 pub struct PistonWindow<W: Window = GlutinWindow> {


### PR DESCRIPTION
- Bumped to 0.59.0

Closes https://github.com/PistonDevelopers/piston_window/issues/173