### PR TITLE
Reexport `gfx_device_gl::Device`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_window"
-version = "0.112.0"
+version = "0.113.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["window", "piston"]
 description = "The official Piston window wrapper for the Piston game engine"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,8 @@ use gfx_graphics::{Gfx2d, GfxGraphics};
 use std::error::Error;
 use std::time::Duration;
 
+/// Actual device used by Gfx backend.
+pub type GfxDevice = gfx_device_gl::Device;
 /// Actual factory used by Gfx backend.
 pub type GfxFactory = gfx_device_gl::Factory;
 /// Actual gfx::Stream implementation carried by the window.


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/piston_window/issues/278

- Bumped to 0.113.0